### PR TITLE
Proposed changes to fully bake all of the CDK libraries into the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM python:3.9-alpine
 
+# Set image labels
 LABEL maintainer="mike@cumulustech.us"
-LABEL cdk_version=1.85.0
 
-#Setup
+# Set build args with defaults
+ARG CDK_VERSION=1.86.0
+
+# Setup
 RUN mkdir /proj
 WORKDIR /proj
 RUN apk -U --no-cache add \
@@ -14,15 +17,19 @@ RUN apk -U --no-cache add \
     npm &&\
     rm -rf /var/cache/apk/*
 
-#Python virtual env
-RUN python -m pip install --upgrade virtualenv
-ENV VIRTUAL_ENV=/proj/.env
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+# Install essential Python packages
+RUN pip install beautifulsoup4 requests 
 
-#node and cdk
-RUN npm install -g aws-cdk@1.85.0
+# Query PyPI registry for all installable CDK modules
+COPY list-cdk-packages.py .
+RUN CDK_PACKAGES=`./list-cdk-packages.py ${CDK_VERSION}` && pip install `echo $CDK_PACKAGES`
 
-#Matt's CDK SSO Plugin https://www.npmjs.com/package/cdk-cross-account-plugin
-RUN npm i -g cdk-cross-account-plugin aws-sdk
+# AWS CDK, AWS SDK, and Matt's CDK SSO Plugin https://www.npmjs.com/package/cdk-cross-account-plugin
+RUN npm i -g aws-cdk@${CDK_VERSION} aws-sdk cdk-cross-account-plugin 
 
+# Install additional Python packages
+# (this is positioned here to take advantage of layer caching)
+RUN pip install Jinja2 stringcase
+
+# Set default run command
 CMD ["/bin/bash"]

--- a/list-cdk-packages.py
+++ b/list-cdk-packages.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import fnmatch
+import re
+import requests
+import sys
+from bs4 import BeautifulSoup
+
+# Request the entire PyPI package index
+print('Fetching PyPI index', file=sys.stderr, end='')
+pypi_response = requests.get('https://pypi.python.org/simple/')
+print(' ... done', file=sys.stderr)
+
+# Configure to parse HTML document
+print('Parsing response', file=sys.stderr, end='')
+soup = BeautifulSoup(pypi_response.text, 'html.parser')
+print(' ... done', file=sys.stderr)
+
+# Regex pattern for parsing package URLs
+pattern = '/simple/aws-cdk-(?P<package>.*)/'
+
+# Iterate <a> elements that link to packages
+for package_link in soup.find_all('a'):
+    url = package_link.get('href')
+
+    # Using filename style pattern matching to identify AWS CDK modules
+    if fnmatch.fnmatch(url, '/simple/aws-cdk-aws*'):
+        # Parse package name
+        matches = re.search(pattern, url)
+
+        # Ignore if no match can be made
+        if matches is None:
+            continue
+
+        package_name = matches.group('package')
+
+        # Ignore if the package ends in -api
+        if package_name.endswith('-api'):
+            continue
+
+        # Ignore selected packages that are not tracking CDK core
+        if package_name in ['aws-quickstarts']:
+            continue
+
+        # Print out package spec suitable for Pip
+        print(f"aws-cdk.{matches.group('package')}=={sys.argv[1]}", end=' ')
+    


### PR DESCRIPTION
After playing with this, I ran into a curious issue of how to deal with a situation of the CDK tooling image having one version of the CDK, but the project itself having a different version of the CDK installed into the Python venv. Having libraries partially installed in the Docker image, but the remainder of them installed locally in the project folder will create all sorts of weird problems.

In that scenario, the user would need to remember to re-run pip any time they changed the tooling image, and they would not be able to easily toggle different versions of images using the `active` tag that we discussed.

The proposed changes here address this as follows:

- Drop the use of virtual env because it's not super useful in a Docker image anyway

- Created script `list-cdk-packages.py` for the Docker build which does some work to ask PyPI for all the CDK packages, and then installs them with Pip with to the requested version tag. Why guess at which CDK packages are needed? Install them all.

_Anything installed for the CDK gets baked into the image, and the developer/end user is not required to install anything into their environment other than having Docker and setting up the Bash aliases for the command line._

- Various tweaks like making the CDK version a build arg, condensed a few lines, and added an option for extra Pip imports because CDK projects open the possibility for interesting things like templating, etc.