### PR TITLE
Add local package support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ LABEL maintainer="mike@cumulustech.us"
 # Set build args with defaults
 ARG CDK_VERSION=1.90.1
 
+# Set PYTHONPATH to support local/project specific packages
+ENV PYTHONPATH="/proj/.python-local"
+
 # Setup
 RUN mkdir /proj
 WORKDIR /proj
@@ -21,6 +24,7 @@ RUN apk -U --no-cache add \
 RUN pip install beautifulsoup4 requests 
 
 # Query PyPI registry for all installable CDK modules
+# (@Feb-22-2021 MR - I would like to replace this in the future with CDK monorepo -- too experimental right now)
 COPY list-cdk-packages.py .
 RUN CDK_PACKAGES=`./list-cdk-packages.py ${CDK_VERSION}` && pip install `echo $CDK_PACKAGES`
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.9-alpine
 LABEL maintainer="mike@cumulustech.us"
 
 # Set build args with defaults
-ARG CDK_VERSION=1.86.0
+ARG CDK_VERSION=1.90.1
 
 # Setup
 RUN mkdir /proj


### PR DESCRIPTION
This enhances the work done in the last PR by adding an escape hatch so that Python _in the CDK image_ can load packages installed locally in a project.

`PYTHONPATH` is an environment variable that the interpreter uses at startup to amend the list of paths searched for packages. By adding one or more directories, we are telling Python look for packages in these locations _in addition to_ the default locations that it will check. The Python module system is very flexible in this regard -- very easy to hot wire without introducing side effects.

Solves the issue that can come up if an implementor using the CDK image would also like to use a specific Python package relevant for their project, but is not something that needs to be baked at build time in the CDK image itself. In theory, `Jinja2` and `stringcase` are like that because we use them for specific needs in our client projects. For someone else, they could be superfluous and unneeded.

There are a couple ways to use this.

**Option 1 - Direct Command:**

Assuming the Bash aliases are set as already defined, the following is an example of installing the Python package [boltons](https://github.com/mahmoud/boltons).

```shell
cdkpip install --target .python-local boltons
```

**Option 2 - Aliases:**

Provides shortcuts to pip commands to ensure package(s) are installed into the local project directory as set in the built image.

```shell
alias cdkpip-install='docker run --rm -it -v ~/.aws:/root/.aws -v $(pwd):/proj cumulusmike/pycdk:active pip install --target .python-local'
```

Uninstalling a package can be done with the existing alias `cdkpip` without providing the `--target` option, e.g. `cdkpip uninstall boltons`.

Implementors should also be reminded to add `.python-local` to a .gitignore file (or similar file if using a different SCM). Avoids the hazard of committing a tree of dependencies by accident -- generally a bad idea.