### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN ./list-cdk-packages.py ${CDK_VERSION} > cdk-requirements.txt &&\
     pip install -r cdk-requirements.txt
 
 # AWS CDK, AWS SDK, and Matt's CDK SSO Plugin https://www.npmjs.com/package/cdk-cross-account-plugin
-RUN npm i -g aws-cdk@${CDK_VERSION} aws-sdk cdk-cross-account-plugin c9
+RUN npm i -g aws-cdk@${CDK_VERSION} aws-sdk cdk-cross-account-plugin
 
 # Install additional Python packages
 # (this is positioned here to take advantage of layer caching)


### PR DESCRIPTION
c9 shouldn't be needed as the npmjs.com/package/cdk-cross-account-plugin included that. 
Part of the: https://github.com/cloudmation-llc/cdk-cross-account-plugin/pull/2