### PR TITLE
Update cdk-bash.sh

### DIFF
--- a/cdk-bash.sh
+++ b/cdk-bash.sh
@@ -1,6 +1,6 @@
 # Docker CDK Bash Env Setup
 # Add to .profile or .bashrc Example:
-#  . ~/docker-pycdk/cdk-bash.sh
+#  . ~/pycdk/cdk-bash.sh
 
 #AWS Example
 # export REGISTRY='421327123456.dkr.REGISTRY.us-west-2.amazonaws.com'


### PR DESCRIPTION
Updated the name as the repository is now called pycdk vs. docker-pycdk previously.